### PR TITLE
Pass numeric array to printf to support PHP 8

### DIFF
--- a/templates/info-filters.php
+++ b/templates/info-filters.php
@@ -37,7 +37,7 @@
 							'filter_name' => $filter,
 							'message'     => __( 'There are no filters use this hook.', 'debug-bar-rewrite-rules' ),
 						);
-						call_user_func_array( 'printf', $arguments );
+						call_user_func_array( 'printf', array_values( $arguments ) );
 						$filter_prev = $filter;
 
 					} else {
@@ -85,7 +85,7 @@
 											'callback_func' => $item[1],
 										);
 								}
-								call_user_func_array( 'printf', $arguments );
+								call_user_func_array( 'printf', array_values( $arguments ) );
 
 							} // End of foreach loop of $items.
 						} // End of foreach loop of $meta['filters'].


### PR DESCRIPTION
PHP 8 requires a numeric array when `call_user_func_array` is called otherwise it 
will attempt to translate the arguments to named parameters.

Fixes `printf() expects at least 1 argument, 0 given` errors. 