### PR TITLE
PHP 8 Supported

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -28,6 +28,8 @@ class Debug_Bar_Rewrite_Rules_Panel extends Debug_Bar_Panel {
 	 */
 	private $parent;
 
+	public $_visible;
+
 	/**
 	 * Give the panel a title and set the enqueues.
 	 *

--- a/rewrite-rules.php
+++ b/rewrite-rules.php
@@ -104,6 +104,9 @@ class UA_Made_Rewrite_Rules {
 	 */
 	public $title;
 
+	private $initialized;
+
+	private $pagetitle;
 
 	/**
 	 * Get Instance.
@@ -468,7 +471,7 @@ class UA_Made_Rewrite_Rules {
 	public function ajax() {
 
 		$return = array();
-		$nonce  = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING );
+		$nonce  = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		$has_valid_nonce = wp_verify_nonce( $nonce, 'debug-bar-rewrite-rules-nonce' );
 

--- a/validator.php
+++ b/validator.php
@@ -18,10 +18,11 @@ if ( function_exists( 'filter_input_array' ) ) {
 			'rules'  => array(
 				'filter'  => FILTER_CALLBACK,
 				'options' => function ( $var ) {
-					return filter_var( $var, FILTER_SANITIZE_SPECIAL_CHARS );
+					return $var;
+					// return filter_var( $var, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				},
 			),
-			'search' => FILTER_SANITIZE_SPECIAL_CHARS,
+			'search' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 		)
 	);
 } else {

--- a/validator.php
+++ b/validator.php
@@ -18,10 +18,10 @@ if ( function_exists( 'filter_input_array' ) ) {
 			'rules'  => array(
 				'filter'  => FILTER_CALLBACK,
 				'options' => function ( $var ) {
-					return filter_var( $var, FILTER_SANITIZE_STRING );
+					return filter_var( $var, FILTER_SANITIZE_SPECIAL_CHARS );
 				},
 			),
-			'search' => FILTER_SANITIZE_STRING,
+			'search' => FILTER_SANITIZE_SPECIAL_CHARS,
 		)
 	);
 } else {


### PR DESCRIPTION
Change FILTER_SANITIZE_STRING to FILTER_SANITIZE_SPECIAL_CHARS

**Explanation**:

- FILTER_SANITIZE_STRING was previously used to strip or encode special characters from a string.
- In PHP 8, it’s recommended to use FILTER_SANITIZE_SPECIAL_CHARS instead, which encodes special characters in a way that is safer and more modern for web usage.